### PR TITLE
fix(GlobalStatistics): Update the response of the /api/v1/global endpoint

### DIFF
--- a/app/Http/Controllers/Api/V1/GlobalStatisticsController.php
+++ b/app/Http/Controllers/Api/V1/GlobalStatisticsController.php
@@ -17,6 +17,10 @@ class GlobalStatisticsController extends Controller
      */
     public function __invoke(Request $request)
     {
-        return new GlobalStatisticsResource(GlobalStatistics::latest('stat_date')->first());
+        $statistics = GlobalStatistics::latest('stat_date')->first();
+        if ($statistics) {
+            return new GlobalStatisticsResource($statistics);
+        }
+        return response()->json(['data' => null]);
     }
 }

--- a/resources/js/components/GlobalStatistics.vue
+++ b/resources/js/components/GlobalStatistics.vue
@@ -8,7 +8,7 @@
 
 <script setup>
 import { ref } from 'vue';
-import { isEmpty, toCommas } from '@/utils/DataUtils';
+import { isEmpty, isNotEmpty, toCommas } from '@/utils/DataUtils';
 import { getGlobalStatistics } from '@/plugins/api-client';
 
 import StatisticItem from './StatisticItem.vue';
@@ -21,7 +21,7 @@ const recovered = ref(UNDEFINED_VALUE_MESSAGE);
 
 const { success, data } = await getGlobalStatistics();
 
-if (success) {
+if (success && isNotEmpty(data)) {
 	confirmed.value = isEmpty(data.confirmed) || data.confirmed == -1 ?
 		UNDEFINED_VALUE_MESSAGE : data.confirmed.toString();
 	deaths.value = isEmpty(data.deaths) || data.deaths == -1 ?

--- a/resources/js/plugins/api-client/index.js
+++ b/resources/js/plugins/api-client/index.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { isEmpty } from "./Utils";
 
 import Response from './Response'
 import GlobalStatistics from "./models/GlobalStatistics";
@@ -56,7 +57,7 @@ async function getGlobalStatistics() {
 	try {
 		const response = await apiClient.get('global');
 		if (response.status === 200) {
-			return new Response(true, null, new GlobalStatistics(response.data.data));
+			return new Response(true, null, isEmpty(response.data.data) ? null : new GlobalStatistics(response.data.data));
 		}
 		return new Response(false, response.data.message, null);
 	} catch (error) {

--- a/resources/js/plugins/api-client/models/Summary.js
+++ b/resources/js/plugins/api-client/models/Summary.js
@@ -1,10 +1,11 @@
 import GlobalStatistics from "./GlobalStatistics";
 import Country from "./Country";
+import { isEmpty } from "../Utils";
 
 export default class Summary {
 
 	constructor(response) {
-		this.global = new GlobalStatistics(response.global);
+		this.global = isEmpty(response.global) ? null : new GlobalStatistics(response.global);
 		this.countries = response.countries.map((country) => new Country(country));
 	}
 


### PR DESCRIPTION
## Summary

Send a request to /api/v1/global will respond with a 500 internal server error when no global statistics can be found.

## Steps to reproduce

There are two ways to reproduce this error:

- Visit the Global screen and check the network panel, a 500 internal server error should be found there.
- Send a direct request to the  /api/v1/global endpoint.

## What is the current bug behavior?

A `null` object was being passed to the `GlobalStatisticsResource`, resulting in an attempt to read a `null` property.

## What is the expected correct behavior?

The server should respond with a `200 OK` and the body should be as below:

```json
{
    "data": null
}
```

## Relevant logs and/or screenshots

Already provided in the opened issue, #1. 
